### PR TITLE
optionally disable boost.chrono in duration.hpp

### DIFF
--- a/include/boost/compute/detail/duration.hpp
+++ b/include/boost/compute/detail/duration.hpp
@@ -17,7 +17,9 @@
 #include <chrono>
 #endif
 
+#ifndef BOOST_COMPUTE_NO_BOOST_CHRONO
 #include <boost/chrono/duration.hpp>
+#endif
 
 namespace boost {
 namespace compute {
@@ -34,6 +36,7 @@ make_duration_from_nanoseconds(std::chrono::duration<Rep, Period>, size_t nanose
 }
 #endif // BOOST_COMPUTE_NO_HDR_CHRONO
 
+#ifndef BOOST_COMPUTE_NO_BOOST_CHRONO
 template<class Rep, class Period>
 inline boost::chrono::duration<Rep, Period>
 make_duration_from_nanoseconds(boost::chrono::duration<Rep, Period>, size_t nanoseconds)
@@ -42,6 +45,7 @@ make_duration_from_nanoseconds(boost::chrono::duration<Rep, Period>, size_t nano
         boost::chrono::nanoseconds(nanoseconds)
     );
 }
+#endif // BOOST_COMPUTE_NO_BOOST_CHRONO
 
 } // end detail namespace
 } // end compute namespace


### PR DESCRIPTION
add BOOST_COMPUTE_NO_BOOST_CHRONO to allow user to not using boost.chrono, which is not a header-only library. Boost.compute is header-only and shall allow user to remain using it header only. Including boost.chrono means that user has no choice but build boost. On the other hand, std::chrono is often header only, and which is available to most platforms today. At least give boost.chrono the same treatment as std::chrono.
